### PR TITLE
ci: add Codecov reporting and an 80% coverage gate

### DIFF
--- a/.github/workflows/build-test-on-pr-main.yaml
+++ b/.github/workflows/build-test-on-pr-main.yaml
@@ -46,4 +46,35 @@ jobs:
       run: make test
 
     - name: Run Go integration tests
-      run: make test-integration  
+      run: make test-integration
+
+    # Coverage runs on a single matrix leg. The figure does not vary by Go
+    # version in any way worth measuring, and running it on all six would send
+    # Codecov six duplicate uploads of the same commit.
+    #
+    # Split into profile / upload / gate rather than one `make
+    # test-coverage-check` step so that a run which fails the floor still
+    # publishes the numbers that explain why.
+    - name: Coverage profile
+      if: matrix.go-version == '1.26'
+      run: make test-coverage-ci
+
+    # Reporting, not gating. Pull requests from forks cannot read the
+    # repository secret, so continue-on-error covers the whole step —
+    # fail_ci_if_error alone does not cover a failed CLI download.
+    - name: Upload coverage to Codecov
+      if: matrix.go-version == '1.26'
+      continue-on-error: true
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        # The unfiltered profile: Codecov applies the `ignore` rules in
+        # codecov.yml itself.
+        files: coverage.out
+        disable_search: true
+        slug: go-monolith/mono
+        fail_ci_if_error: false
+
+    - name: Coverage floor
+      if: matrix.go-version == '1.26'
+      run: ./scripts/coverage-gate.sh coverage.out

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -27,3 +27,18 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.11.4
+
+      # Workflow files are the one part of the repository that CI cannot
+      # validate by running it: a typo in a matrix reference or an `if:`
+      # condition fails open, silently skipping the step it guards rather than
+      # erroring. actionlint catches those statically.
+      #
+      # Installed and run through the Makefile so ACTIONLINT_VERSION stays the
+      # single source of truth. Hardcoding the version here as well would
+      # recreate exactly the kind of two-copy drift internal/covergate exists to
+      # catch. Ubuntu runners ship shellcheck, which actionlint picks up
+      # automatically to lint every `run:` block.
+      - name: actionlint
+        run: |
+          make install-actionlint
+          PATH="$(go env GOPATH)/bin:$PATH" make lint-actions

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,10 +23,15 @@ jobs:
       - name: Run preparation steps
         run: ./configure.sh
 
+      # Keep in step with GOLANGCI_LINT_VERSION in the Makefile. The version
+      # must be built with a Go release at least as new as `stable` above:
+      # golangci-lint type-checks the standard library from source, so an
+      # older binary panics with "file requires newer Go version" as soon as
+      # `stable` advances. That is what broke this job when Go 1.27 shipped.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.11.4
+          version: v2.13.1
 
       # Workflow files are the one part of the repository that CI cannot
       # validate by running it: a typo in a matrix reference or an `if:`

--- a/.github/workflows/release-on-push-main.yaml
+++ b/.github/workflows/release-on-push-main.yaml
@@ -192,9 +192,11 @@ jobs:
           } > bench_release_notes.md
 
           # Store for multiline output
-          echo "notes_file=bench_release_notes.md" >> "$GITHUB_OUTPUT"
-          echo "total=$TOTAL_BENCHMARKS" >> "$GITHUB_OUTPUT"
-          echo "framework_total=$FRAMEWORK_BENCHMARKS" >> "$GITHUB_OUTPUT"
+          {
+            echo "notes_file=bench_release_notes.md"
+            echo "total=$TOTAL_BENCHMARKS"
+            echo "framework_total=$FRAMEWORK_BENCHMARKS"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Calculate next version
         id: version

--- a/.github/workflows/release-on-push-main.yaml
+++ b/.github/workflows/release-on-push-main.yaml
@@ -53,6 +53,24 @@ jobs:
       - name: Run integration tests
         run: make test-integration
 
+      # This is what gives Codecov a main-branch base report; without it the
+      # per-pull-request coverage deltas have nothing to diff against.
+      - name: Coverage profile
+        run: make test-coverage-ci
+
+      - name: Upload coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          disable_search: true
+          slug: go-monolith/mono
+          fail_ci_if_error: false
+
+      - name: Coverage floor
+        run: ./scripts/coverage-gate.sh coverage.out
+
       - name: Run benchmarks
         run: make bench-all-save-json
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,10 +40,19 @@ make test-coverage      # Generate coverage report (opens coverage.html)
 ```bash
 make fmt                # Format code (gofmt + goimports)
 make vet                # Run go vet
-make lint               # Run golangci-lint
+make lint               # Run all linters (Go + GitHub Actions workflows)
+make lint-go            # Run golangci-lint only
+make lint-actions       # Run actionlint over .github/workflows only
 make lint-fix           # Run linter with auto-fix
 make check              # Run all quality checks (fmt, vet, lint, test-short)
 ```
+
+`make lint-actions` needs `actionlint`, which `make install` provides. Workflow
+files are the one part of the repository CI cannot validate by running it: a
+typo in a matrix reference or an `if:` condition fails open, silently skipping
+the step it guards instead of erroring. actionlint catches that statically, and
+it also runs `shellcheck` over every `run:` block when shellcheck is on PATH —
+worth installing locally, since CI has it and will catch what you don't.
 
 ### Building
 
@@ -125,7 +134,7 @@ mono-framework/
 ### Go Conventions
 
 - **Formatting**: All code must pass `gofmt` and `go vet`
-- **Linting**: All code must pass `golangci-lint`
+- **Linting**: All code must pass `golangci-lint`; workflow files must pass `actionlint`
 - **Naming**: Follow Go naming conventions (CamelCase for exports, camelCase for unexported)
 
 ### Documentation

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@ GOLANGCI_LINT_VERSION := v2.11.4
 # Pinned golang.org/x/tools version for goimports, so formatting tooling
 # upgrades are deliberate rather than silently picked up via @latest.
 GOIMPORTS_VERSION := v0.48.0
+# Pinned actionlint version, for the same reason: a new release adding a rule
+# should break the build on a deliberate bump rather than on an unrelated day.
+ACTIONLINT_VERSION := v1.7.12
 GOFMT := gofmt
 GOIMPORTS := goimports
+ACTIONLINT := actionlint
 COVERAGE_FILE := coverage.out
 COVERAGE_HTML := coverage.html
 # Profile with the out-of-scope packages stripped; written by
@@ -27,7 +31,7 @@ BUILD_FLAGS := -v
 TEST_FLAGS := -v -race
 BENCH_FLAGS := -benchmem
 
-.PHONY: help test test-short test-all test-coverage test-coverage-ci test-coverage-check test-verbose lint lint-fix fmt vet build clean bench bench-json bench-json-inprocess bench-json-socket install install-tools check mod-tidy mod-download mod-verify pre-commit test-integration
+.PHONY: help test test-short test-all test-coverage test-coverage-ci test-coverage-check test-verbose lint lint-go lint-actions lint-fix fmt vet build clean bench bench-json bench-json-inprocess bench-json-socket install install-tools install-actionlint check mod-tidy mod-download mod-verify pre-commit test-integration
 
 # Default target
 .DEFAULT_GOAL := help
@@ -37,6 +41,7 @@ install:
 	@echo "Installing development tools..."
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$($(GO) env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 	@$(GO) install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	@$(GO) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
 	@echo "✓ Development tools installed successfully"
 
 # Run unit tests only (excludes test/ directory)
@@ -104,10 +109,33 @@ test-coverage-ci:
 test-coverage-check: test-coverage-ci
 	@./scripts/coverage-gate.sh $(COVERAGE_FILE) $(COVERAGE_THRESHOLD)
 
-# Run linter
-lint:
+# Run all linters
+lint: lint-go lint-actions
+
+# Run the Go linter
+lint-go:
 	@echo "Running golangci-lint..."
 	@$(GOLANGCI_LINT) run ./...
+
+# Lint the GitHub Actions workflows.
+#
+# actionlint checks what a YAML parser cannot: undefined matrix properties,
+# expression type errors, unknown action inputs, invalid `if:` conditions. When
+# shellcheck is on PATH it also lints every `run:` block, which is where the
+# release workflow's benchmark parsing lives — so install shellcheck too if you
+# want the full check locally (CI has it).
+#
+# Missing tooling is an error rather than a skip: a linter that quietly does
+# nothing reports success it has not earned.
+lint-actions:
+	@echo "Running actionlint..."
+	@command -v $(ACTIONLINT) >/dev/null 2>&1 || { \
+		echo "actionlint not found on PATH. Install it with: make install"; \
+		echo "(and ensure \$$(go env GOPATH)/bin is on your PATH)"; \
+		exit 1; \
+	}
+	@$(ACTIONLINT)
+	@echo "✓ Workflows passed actionlint"
 
 # Run linter with auto-fix
 lint-fix:
@@ -179,11 +207,19 @@ mod-verify:
 	@$(GO) mod verify
 	@echo "Dependencies verified successfully"
 
+# Install actionlint only.
+#
+# CI's lint job uses this rather than hardcoding a version in the workflow, so
+# ACTIONLINT_VERSION stays the single source of truth for the pin.
+install-actionlint:
+	@$(GO) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
+
 # Install development tools
 install-tools:
 	@echo "Installing development tools..."
 	@$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@$(GO) install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+	@$(GO) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
 	@echo "✓ Development tools installed successfully"
 
 # Run example 1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ GOLANGCI_LINT := golangci-lint
 # Single source of truth for the golangci-lint version; must match the
 # `version:` pin in .github/workflows/golangci-lint.yaml so local lint
 # results match CI regardless of which install target is used.
-GOLANGCI_LINT_VERSION := v2.11.4
+#
+# Must also be built with a Go release at least as new as the toolchain CI
+# uses: golangci-lint parses the standard library from source, so an older
+# binary panics with "file requires newer Go version" the moment `stable`
+# advances. v2.13.1 is the first release built with go1.27.
+GOLANGCI_LINT_VERSION := v2.13.1
 # Pinned golang.org/x/tools version for goimports, so formatting tooling
 # upgrades are deliberate rather than silently picked up via @latest.
 GOIMPORTS_VERSION := v0.48.0

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,20 @@ GOFMT := gofmt
 GOIMPORTS := goimports
 COVERAGE_FILE := coverage.out
 COVERAGE_HTML := coverage.html
+# Profile with the out-of-scope packages stripped; written by
+# scripts/coverage-gate.sh, which owns the exclusion list.
+COVERAGE_FILTERED := coverage.filtered.out
+# Minimum statement coverage enforced by `test-coverage-check`. Assigned with
+# ?= so it can be overridden from the environment or the command line, e.g.
+# `make COVERAGE_THRESHOLD=90 test-coverage-check`.
+COVERAGE_THRESHOLD ?= 80
 
 # Go build flags
 BUILD_FLAGS := -v
 TEST_FLAGS := -v -race
 BENCH_FLAGS := -benchmem
 
-.PHONY: help test test-short test-all test-coverage test-verbose lint lint-fix fmt vet build clean bench bench-json bench-json-inprocess bench-json-socket install install-tools check mod-tidy mod-download mod-verify pre-commit test-integration
+.PHONY: help test test-short test-all test-coverage test-coverage-ci test-coverage-check test-verbose lint lint-fix fmt vet build clean bench bench-json bench-json-inprocess bench-json-socket install install-tools check mod-tidy mod-download mod-verify pre-commit test-integration
 
 # Default target
 .DEFAULT_GOAL := help
@@ -74,6 +81,29 @@ test-coverage:
 	@echo "Coverage report generated: $(COVERAGE_HTML)"
 	@echo "View it with: open $(COVERAGE_HTML)"
 
+# Produce a coverage profile for CI and for the coverage gate.
+#
+# Differs from test-coverage in three ways: no -v (the full verbose log of a
+# -race run buries everything else in the CI output), no HTML report, and the
+# same 3-attempt retry as the `test` target — the unit suite is flaky enough
+# under -race that a single-shot run would regularly leave the gate with no
+# profile to measure.
+test-coverage-ci:
+	@echo "Running unit tests with coverage (up to 3 attempts)..."
+	@for i in 1 2 3; do \
+		echo "Attempt $$i/3"; \
+		if $(GO) test -race -covermode=atomic -coverprofile=$(COVERAGE_FILE) ./...; then \
+			echo "Coverage profile written to $(COVERAGE_FILE) on attempt $$i"; \
+			exit 0; \
+		fi; \
+	done; \
+	echo "Coverage run failed after 3 attempts"; \
+	exit 1
+
+# Enforce the coverage floor. The gate script owns the exclusion list.
+test-coverage-check: test-coverage-ci
+	@./scripts/coverage-gate.sh $(COVERAGE_FILE) $(COVERAGE_THRESHOLD)
+
 # Run linter
 lint:
 	@echo "Running golangci-lint..."
@@ -123,7 +153,7 @@ bench-all-save-json:
 # Clean build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
-	@rm -f $(COVERAGE_FILE) $(COVERAGE_HTML)
+	@rm -f $(COVERAGE_FILE) $(COVERAGE_FILTERED) $(COVERAGE_HTML)
 	@$(GO) clean -cache -testcache -modcache ./...
 	@echo "Clean completed successfully"
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-monolith/mono.svg)](https://pkg.go.dev/github.com/go-monolith/mono)
 [![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)](https://golang.org/dl/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Coverage](https://img.shields.io/badge/coverage-90.1%25-brightgreen.svg)](docs/official/extra/code-coverage.md)
+[![codecov](https://codecov.io/gh/go-monolith/mono/graph/badge.svg)](https://codecov.io/gh/go-monolith/mono)
 
 A Go framework for building **distributed modular monolith** applications powered by NATS.io.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,45 @@
+# Codecov configuration for github.com/go-monolith/mono
+#
+# Codecov reports the number; scripts/coverage-gate.sh is what enforces it.
+# The project status below mirrors the gate's floor so the Codecov check and
+# the CI job agree rather than contradict each other.
+
+coverage:
+  status:
+    project:
+      default:
+        # Same floor as COVERAGE_THRESHOLD in the Makefile.
+        target: 80%
+        # Absorbs the sub-percent jitter of a -race run without letting a real
+        # regression through.
+        threshold: 1%
+    patch:
+      default:
+        # Informational: a strict per-diff target turns documentation and
+        # refactoring pull requests red for no useful reason. The project
+        # floor is the check that means something.
+        informational: true
+
+# Comment only when the diff actually moves coverage, so documentation and
+# workflow pull requests stay quiet.
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true
+
+# A Go coverage profile names files by import path, so every line in
+# coverage.out starts with the module path, while the `ignore` globs below are
+# root-anchored. Stripping the prefix here is what makes them match at all.
+fixes:
+  - "github.com/go-monolith/mono/::"
+
+# Packages excluded from the reported figure. Keep this list in lockstep with
+# EXCLUDE_RE in scripts/coverage-gate.sh — the two drifting apart is how the
+# badge and the gate end up reporting different numbers.
+#
+#   examples/  documentation programs, no tests by design
+#   bench/     benchmarks and the benchmark JSON parser
+#   test/      integration suite, run separately under -tags=integration
+ignore:
+  - "examples/**"
+  - "bench/**"
+  - "test/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,7 +34,9 @@ fixes:
 
 # Packages excluded from the reported figure. Keep this list in lockstep with
 # EXCLUDE_RE in scripts/coverage-gate.sh — the two drifting apart is how the
-# badge and the gate end up reporting different numbers.
+# badge and the gate end up reporting different numbers. internal/covergate
+# enforces that; it parses these entries, so changing their shape fails those
+# tests.
 #
 #   examples/  documentation programs, no tests by design
 #   bench/     benchmarks and the benchmark JSON parser

--- a/docs/official/extra/code-coverage.md
+++ b/docs/official/extra/code-coverage.md
@@ -41,6 +41,8 @@ make COVERAGE_THRESHOLD=90 test-coverage-check
 
 Three trees are excluded from the enforced figure. Including them would measure how much example and benchmark code the repository carries rather than how well the framework itself is tested — `examples/` alone drags the raw number from ~92% down to ~61%.
 
+Expect the exact figure to move a little with the Go release you build under: the compiler's statement-counting granularity changes between versions, so the same tree reports 3807 in-scope statements under Go 1.26 and 5226 under Go 1.27 (91.2% and 92.4% respectively). The percentage barely shifts, but any check written against an absolute statement count has to tolerate the spread.
+
 | Excluded | Why |
 | --- | --- |
 | `examples/` | Documentation programs, built and run by `make run-example-*` rather than unit tested |

--- a/docs/official/extra/code-coverage.md
+++ b/docs/official/extra/code-coverage.md
@@ -52,7 +52,11 @@ This list lives in two places and the two must stay in lockstep:
 - `EXCLUDE_RE` in [`scripts/coverage-gate.sh`](../../../scripts/coverage-gate.sh) — governs the enforced floor
 - `ignore:` in [`codecov.yml`](../../../codecov.yml) — governs the badge and the dashboard
 
-If they drift apart, the badge and the gate report different numbers. `codecov.yml` also needs its `fixes:` entry, which strips the `github.com/go-monolith/mono/` import-path prefix that Go writes into every profile line; without it Codecov's root-anchored ignore globs match nothing.
+If they drift apart the badge and the gate report different numbers for the same commit, and nothing at runtime notices. That lockstep is enforced by [`internal/covergate`](../../../internal/covergate/exclusions_test.go), a test-only package that parses both files and fails when they name different directories. It runs under `make test`, `make test-short` and `make check`, so a mismatch fails CI rather than sitting undetected.
+
+The same tests also check that both files agree with the module path in `go.mod`. `codecov.yml` needs its `fixes:` entry to strip the `github.com/go-monolith/mono/` import-path prefix that Go writes into every profile line — without it Codecov's root-anchored ignore globs match nothing, and every exclusion silently becomes a no-op.
+
+Changing the exclusions therefore means editing both files together. If the shape of either changes enough that the guard can no longer parse it, the guard fails loudly and asks to be updated — that is deliberate, since a drift guard that quietly parses nothing is worse than no guard at all.
 
 ## Coverage in CI
 

--- a/docs/official/extra/code-coverage.md
+++ b/docs/official/extra/code-coverage.md
@@ -1,112 +1,80 @@
 # Code Coverage
 
-This page documents the test coverage statistics for the Monolith Framework. Coverage is measured using Go's built-in coverage tools with atomic mode for accurate results.
+This page documents how test coverage is measured and enforced for the Monolith Framework. Coverage uses Go's built-in tooling in atomic mode, which is required for accurate counts under `-race`.
 
 ## Overview
 
+The live coverage figure is published to Codecov — that dashboard, not this page, is the source of truth:
+
+[![codecov](https://codecov.io/gh/go-monolith/mono/graph/badge.svg)](https://codecov.io/gh/go-monolith/mono)
+
 | Metric | Value |
 |--------|-------|
-| **Overall Coverage** | 90.1% |
-| **Test Command** | `go test -coverprofile=coverage.out -covermode=atomic ./...` |
-| **Last Updated** | December 2024 |
+| **Enforced floor** | 80% statement coverage |
+| **Enforced by** | `scripts/coverage-gate.sh`, run in CI on every pull request and every push to `main` |
+| **Local command** | `make test-coverage-check` |
+| **Dashboard** | [codecov.io/gh/go-monolith/mono](https://codecov.io/gh/go-monolith/mono) |
 
-## Coverage by Package
-
-### Public API Packages (`pkg/`)
-
-| Package | Coverage | Description |
-|---------|----------|-------------|
-| `pkg/types` | 100.0% | Core interfaces and type definitions |
-| `pkg/errors` | 99.4% | Error handling utilities |
-| `pkg/helper` | 99.1% | Helper functions for common tasks |
-
-### Internal Implementation (`internal/`)
-
-| Package | Coverage | Description |
-|---------|----------|-------------|
-| `internal/logger` | 100.0% | Logger implementation |
-| `internal/middleware` | 100.0% | Middleware chain execution |
-| `internal/eventbus` | 97.5% | EventBus implementation (NATS wrapper) |
-| `internal/registry` | 97.7% | Module and event registry |
-| `internal/app` | 96.9% | Framework application lifecycle |
-| `internal/lifecycle` | 96.7% | Module lifecycle and startup order |
-| `internal/container` | 96.2% | ServiceContainer implementation |
-| `internal/nats` | 91.4% | NATS server setup and embedded server |
-
-### Middleware (`middleware/`)
-
-| Package | Coverage | Description |
-|---------|----------|-------------|
-| `middleware/requestid` | 100.0% | Request ID injection middleware |
-| `middleware/accesslog` | 99.0% | Access logging middleware |
-| `middleware/audit` | 99.0% | Audit logging middleware |
-
-### Plugins (`plugin/`)
-
-| Package | Coverage | Description |
-|---------|----------|-------------|
-| `plugin/fs-jetstream` | 99.3% | File storage plugin for JetStream |
-| `plugin/kv-jetstream` | 79.8% | Key-Value storage plugin |
-
-## Coverage Targets
-
-The framework maintains the following coverage targets:
-
-| Category | Target | Current Status |
-|----------|--------|----------------|
-| Public API (`pkg/`) | 95%+ | Achieved (99%+) |
-| Internal Core (`internal/`) | 90%+ | Achieved (96%+) |
-| Middleware | 95%+ | Achieved (99%+) |
-| Plugins | 80%+ | Achieved |
-| **Overall** | **85%+** | **Achieved (90.1%)** |
+The floor is a hard gate: a pull request that drops in-scope coverage below 80% fails CI. It is expected to ratchet upward over time — lowering `COVERAGE_THRESHOLD` to turn a red build green is not the fix.
 
 ## Running Coverage Locally
 
-To generate a coverage report locally:
-
 ```bash
-# Run tests with coverage (excluding examples)
-go test -coverprofile=coverage.out -covermode=atomic ./...
+# Produce a profile and enforce the 80% floor (what CI runs)
+make test-coverage-check
 
-# View coverage summary
-go tool cover -func=coverage.out
+# Profile only, no gate
+make test-coverage-ci
 
-# Generate HTML report
-go tool cover -html=coverage.out -o coverage.html
+# Profile plus an HTML report for browsing uncovered lines
+make test-coverage
+open coverage.html        # macOS
+xdg-open coverage.html    # Linux
 
-# Open HTML report in browser
-open coverage.html  # macOS
-xdg-open coverage.html  # Linux
+# Check against a stricter floor without editing anything
+make COVERAGE_THRESHOLD=90 test-coverage-check
 ```
+
+`make test-coverage-check` prints the full per-package breakdown before its verdict, so a failure names the packages that need tests.
 
 ## Coverage Exclusions
 
-The following directories are excluded from coverage metrics:
+Three trees are excluded from the enforced figure. Including them would measure how much example and benchmark code the repository carries rather than how well the framework itself is tested — `examples/` alone drags the raw number from ~92% down to ~61%.
 
-- `examples/` - Example code for documentation purposes
-- `bench/` - Performance benchmarks
-- `test/integration/` - Integration tests (tests themselves are excluded)
+| Excluded | Why |
+| --- | --- |
+| `examples/` | Documentation programs, built and run by `make run-example-*` rather than unit tested |
+| `bench/` | Performance benchmarks and the benchmark JSON parser |
+| `test/` | Integration suite, run separately via `make test-integration` under `-tags=integration` |
+
+This list lives in two places and the two must stay in lockstep:
+
+- `EXCLUDE_RE` in [`scripts/coverage-gate.sh`](../../../scripts/coverage-gate.sh) — governs the enforced floor
+- `ignore:` in [`codecov.yml`](../../../codecov.yml) — governs the badge and the dashboard
+
+If they drift apart, the badge and the gate report different numbers. `codecov.yml` also needs its `fixes:` entry, which strips the `github.com/go-monolith/mono/` import-path prefix that Go writes into every profile line; without it Codecov's root-anchored ignore globs match nothing.
+
+## Coverage in CI
+
+Coverage runs on a single Go version leg of the pull-request matrix — the figure does not meaningfully vary by toolchain version, and running it on all six would send Codecov six duplicate uploads of the same commit. The push-to-`main` workflow uploads too, which is what gives Codecov a base report for per-pull-request deltas.
+
+Each workflow runs three separate steps rather than one combined target:
+
+1. **Coverage profile** — `make test-coverage-ci`
+2. **Upload to Codecov** — `codecov/codecov-action@v5`, marked `continue-on-error` because pull requests from forks cannot read `CODECOV_TOKEN`
+3. **Coverage floor** — `scripts/coverage-gate.sh`
+
+The upload deliberately comes before the gate, so a run that fails the floor still publishes the numbers that explain why.
 
 ## Improving Coverage
 
 When contributing to the framework, ensure:
 
-1. **New code has tests** - All new public functions and methods should have corresponding tests
-2. **Edge cases are covered** - Include tests for error conditions and boundary cases
-3. **Coverage doesn't decrease** - Pull requests should maintain or improve overall coverage
-
-### Areas for Improvement
-
-| Package | Current | Target | Notes |
-|---------|---------|--------|-------|
-| `plugin/kv-jetstream` | 79.8% | 90%+ | Additional edge case testing needed |
-| `internal/nats` | 91.4% | 95%+ | More error path coverage needed |
+1. **New code has tests** — all new public functions and methods should have corresponding tests
+2. **Edge cases are covered** — include tests for error conditions and boundary cases
+3. **Coverage doesn't decrease** — the Codecov comment on your pull request shows exactly which lines your diff left uncovered
 
 ## Related Documentation
 
-- [Testing Guide](../guides/testing.md) - How to write tests for modules
-- [Error Handling](../guides/error-handling.md) - Error handling patterns to test
-
----
-
-Coverage statistics are updated with each major release. For the most current coverage data, run the tests locally using the commands above.
+- [Testing Guide](../guides/testing.md) — how to write tests for modules
+- [Error Handling](../guides/error-handling.md) — error handling patterns to test

--- a/internal/covergate/doc.go
+++ b/internal/covergate/doc.go
@@ -1,0 +1,28 @@
+// Package covergate guards the coverage tooling's own configuration.
+//
+// It deliberately contains no runtime code. What it checks is not Go source
+// but three files that have to agree with each other:
+//
+//   - scripts/coverage-gate.sh, whose EXCLUDE_RE decides which packages count
+//     toward the enforced coverage floor
+//   - codecov.yml, whose ignore globs decide which packages count toward the
+//     figure on the badge and dashboard, and whose fixes entry strips the
+//     module prefix that Go writes into every profile line
+//   - go.mod, whose module path both of the above hardcode
+//
+// Nothing at runtime forces those to match. When they drift the failure is
+// silent in the worst way: CI stays green while the badge and the gate report
+// different numbers for the same commit. Comments in both files ask for
+// lockstep; the tests in this package are what enforce it.
+//
+// Living here rather than in a shell script is deliberate. Neither CI workflow
+// runs "make check", so a script wired to that target would never guard
+// anything on a pull request. A Go test is picked up by "go list ./..." and so
+// runs under "make test", "make test-short" and both workflows without any
+// extra wiring.
+//
+// Every parser here fails loudly rather than returning an empty result. A
+// drift guard that quietly parses nothing is worse than no guard at all, so
+// the parsers are pure functions returning errors and are themselves covered
+// by table-driven tests — the guard's own logic must not be allowed to rot.
+package covergate

--- a/internal/covergate/exclusions_test.go
+++ b/internal/covergate/exclusions_test.go
@@ -1,0 +1,375 @@
+package covergate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Paths checked by this package, relative to the repository root.
+const (
+	gateScriptPath    = "scripts/coverage-gate.sh"
+	codecovConfigPath = "codecov.yml"
+	goModPath         = "go.mod"
+)
+
+// excludeRePattern pulls the two interesting pieces out of the gate script's
+// EXCLUDE_RE assignment:
+//
+//	EXCLUDE_RE='^github\.com/go-monolith/mono/(examples|bench|test)/'
+//
+// Submatch 1 is the module prefix as written (dots still backslash-escaped for
+// the shell's grep -E), submatch 2 the pipe-separated directory alternation.
+//
+// Matching the exact shape is the point rather than an inconvenience: if
+// someone rewrites the exclusion into a form this does not recognise, the
+// parse fails and says so. Silently falling back to "no exclusions parsed,
+// therefore nothing to compare" is the one outcome that would make this
+// package useless.
+var excludeRePattern = regexp.MustCompile(`^EXCLUDE_RE='\^(.+?)/\((.+?)\)/'$`)
+
+// excludeReUsePattern matches the point where the gate script actually applies
+// EXCLUDE_RE. Without this check the variable could be assigned correctly and
+// never used, leaving the gate excluding nothing while both drift tests pass.
+var excludeReUsePattern = regexp.MustCompile(`grep\s+-Ev\s+"\$EXCLUDE_RE"`)
+
+// fixesPattern matches the codecov.yml fixes entry that strips the module
+// import path from profile lines, e.g.
+//
+//   - "github.com/go-monolith/mono/::"
+var fixesPattern = regexp.MustCompile(`^\s*-\s*"(.+?)/::"\s*$`)
+
+// ignoreGlobPattern matches one entry of the codecov.yml ignore list and
+// captures the directory it names, e.g. `- "examples/**"` yields "examples".
+var ignoreGlobPattern = regexp.MustCompile(`^\s*-\s*"(.+?)/\*\*"\s*$`)
+
+// modulePattern matches the go.mod module directive.
+var modulePattern = regexp.MustCompile(`^module\s+(\S+)$`)
+
+// TestCoverageExclusionsAgree fails when the gate script and codecov.yml
+// exclude different sets of directories.
+func TestCoverageExclusionsAgree(t *testing.T) {
+	root := repoRoot(t)
+
+	_, gateDirs := mustParseGateScript(t, root)
+	codecovDirs := mustParseCodecovIgnores(t, root)
+
+	if diff := diffSets(gateDirs, codecovDirs); diff != "" {
+		t.Errorf("coverage exclusions have drifted apart:\n%s\n"+
+			"EXCLUDE_RE in %s and the ignore globs in %s must name the same directories.\n"+
+			"When they differ, the enforced floor and the Codecov badge measure different\n"+
+			"sets of packages and report different numbers for the same commit.",
+			diff, gateScriptPath, codecovConfigPath)
+	}
+}
+
+// TestExcludedDirectoriesExist fails when the exclusions name a directory that
+// is no longer in the repository.
+//
+// Both files can agree perfectly on a stale name, in which case the exclusions
+// quietly become no-ops and neither drift test notices. Renaming an excluded
+// tree is exactly the kind of change that would leave them behind.
+func TestExcludedDirectoriesExist(t *testing.T) {
+	root := repoRoot(t)
+
+	_, dirs := mustParseGateScript(t, root)
+	for _, dir := range dirs {
+		info, err := os.Stat(filepath.Join(root, dir))
+		if err != nil {
+			t.Errorf("the coverage exclusions name %q, which does not exist in the repository: %v\n"+
+				"A stale exclusion silently matches nothing. Update %s and %s together.",
+				dir, err, gateScriptPath, codecovConfigPath)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("the coverage exclusions name %q, which exists but is not a directory", dir)
+		}
+	}
+}
+
+// TestGateScriptAppliesItsExclusions fails when EXCLUDE_RE is assigned but
+// never used.
+//
+// The two drift tests compare the assignment against codecov.yml, so a script
+// that computes the right pattern and then forgets to filter with it would
+// still pass them while excluding nothing at all.
+func TestGateScriptAppliesItsExclusions(t *testing.T) {
+	root := repoRoot(t)
+	data := readFile(t, filepath.Join(root, gateScriptPath))
+
+	if !excludeReUsePattern.MatchString(data) {
+		t.Errorf("%s assigns EXCLUDE_RE but never applies it via a %s filter.\n"+
+			"The pattern would be computed and discarded, so every package would count "+
+			"toward the floor regardless of the exclusion list.",
+			gateScriptPath, excludeReUsePattern)
+	}
+}
+
+// TestCoverageConfigUsesTheRealModulePath fails when either file hardcodes a
+// module path that go.mod no longer declares.
+//
+// This is the same class of silent drift as the exclusion lists. A Go coverage
+// profile names files by import path, so both the gate's EXCLUDE_RE and
+// codecov.yml's fixes entry have the module path baked into them. Rename the
+// module and neither one errors: the gate simply stops excluding anything and
+// Codecov's root-anchored ignore globs stop matching, both reporting a
+// plausible-looking but wrong figure.
+func TestCoverageConfigUsesTheRealModulePath(t *testing.T) {
+	root := repoRoot(t)
+
+	module, err := parseModulePath(readFile(t, filepath.Join(root, goModPath)))
+	if err != nil {
+		t.Fatalf("cannot read the module path from %s: %v", goModPath, err)
+	}
+
+	gateModule, _ := mustParseGateScript(t, root)
+	if gateModule != module {
+		t.Errorf("EXCLUDE_RE in %s is anchored to module %q, but go.mod declares %q.\n"+
+			"The exclusions match nothing until these agree, so the gate would measure every package.",
+			gateScriptPath, gateModule, module)
+	}
+
+	fixesModule, err := parseCodecovFixes(readFile(t, filepath.Join(root, codecovConfigPath)))
+	if err != nil {
+		t.Fatalf("cannot read the fixes entry from %s: %v", codecovConfigPath, err)
+	}
+	if fixesModule != module {
+		t.Errorf("the fixes: entry in %s strips prefix %q, but go.mod declares %q.\n"+
+			"Codecov's ignore globs are root-anchored, so they match nothing until these agree.",
+			codecovConfigPath, fixesModule, module)
+	}
+}
+
+// The parsers below are pure functions over file contents so that their own
+// behaviour can be tested directly; see parsers_test.go. The mustParse
+// wrappers read the real files and turn a parse error into a fatal test
+// failure.
+
+// parseGateScript returns the module prefix and the excluded directories named
+// by EXCLUDE_RE in the coverage gate script.
+//
+// Exactly one assignment must be present. Bash uses the last assignment that
+// executes, so accepting several and reading the first would let this package
+// validate a value the script never applies.
+func parseGateScript(content string) (module string, dirs []string, err error) {
+	var matches [][]string
+	for line := range strings.SplitSeq(content, "\n") {
+		if m := excludeRePattern.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			matches = append(matches, m)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		m := matches[0]
+		// The shell side needs `\.` so grep -E treats the dots literally;
+		// compare against go.mod without them.
+		return strings.ReplaceAll(m[1], `\.`, "."), strings.Split(m[2], "|"), nil
+	case 0:
+		return "", nil, fmt.Errorf("no EXCLUDE_RE assignment matching %s found; "+
+			"if the exclusion list moved or changed shape, update this package to match "+
+			"rather than deleting it, or the two exclusion lists go back to being unenforced",
+			excludeRePattern)
+	default:
+		return "", nil, fmt.Errorf("found %d EXCLUDE_RE assignments, expected exactly 1; "+
+			"the shell applies whichever executes last, so this package cannot tell which one is live",
+			len(matches))
+	}
+}
+
+// parseCodecovIgnores returns the directories named by the ignore list in
+// codecov.yml.
+//
+// The block is found by scanning for a top-level ignore key and collecting the
+// list entries that follow it. That is enough structure for a file of this
+// size and shape, and avoids taking on a YAML dependency for one assertion —
+// the foundation spec caps this module's dependencies at NATS and the standard
+// library. Exactly one such block must be present, since a duplicate key later
+// in the file is what Codecov would actually use.
+func parseCodecovIgnores(content string) ([]string, error) {
+	var (
+		dirs     []string
+		inIgnore bool
+		blocks   int
+	)
+
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// A line at column zero starts a new top-level key. List entries are
+		// exempt so that an unindented ignore list still parses.
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "-") {
+			inIgnore = trimmed == "ignore:"
+			if inIgnore {
+				blocks++
+			}
+			continue
+		}
+
+		if !inIgnore {
+			continue
+		}
+
+		m := ignoreGlobPattern.FindStringSubmatch(line)
+		if m == nil {
+			return nil, fmt.Errorf("unrecognised entry in the ignore list: %q; "+
+				"entries are expected to look like `- \"examples/**\"`, so update this "+
+				"package if the convention changed rather than leaving the lists unguarded",
+				trimmed)
+		}
+		dirs = append(dirs, m[1])
+	}
+
+	switch {
+	case blocks == 0:
+		return nil, fmt.Errorf("no top-level ignore: key found")
+	case blocks > 1:
+		return nil, fmt.Errorf("found %d top-level ignore: keys, expected exactly 1; "+
+			"Codecov uses the last one, so this package cannot tell which is live", blocks)
+	case len(dirs) == 0:
+		return nil, fmt.Errorf("the ignore: list is empty; the gate script excludes packages, so this cannot be right")
+	}
+	return dirs, nil
+}
+
+// parseCodecovFixes returns the module prefix stripped by the codecov.yml
+// fixes entry. Exactly one entry must be present.
+func parseCodecovFixes(content string) (string, error) {
+	var found []string
+	for line := range strings.SplitSeq(content, "\n") {
+		if m := fixesPattern.FindStringSubmatch(line); m != nil {
+			found = append(found, m[1])
+		}
+	}
+
+	switch len(found) {
+	case 1:
+		return found[0], nil
+	case 0:
+		return "", fmt.Errorf("no fixes: entry of the form `- \"<module>/::\"` found; " +
+			"without it Codecov's root-anchored ignore globs never match the import paths " +
+			"a Go profile contains, and every exclusion silently becomes a no-op")
+	default:
+		return "", fmt.Errorf("found %d fixes: prefix entries, expected exactly 1", len(found))
+	}
+}
+
+// parseModulePath returns the module path declared by go.mod.
+func parseModulePath(content string) (string, error) {
+	for line := range strings.SplitSeq(content, "\n") {
+		if m := modulePattern.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			return m[1], nil
+		}
+	}
+	return "", fmt.Errorf("no module directive found")
+}
+
+// mustParseGateScript reads the real gate script and fails the test if it
+// cannot be parsed.
+func mustParseGateScript(t *testing.T, root string) (module string, dirs []string) {
+	t.Helper()
+
+	module, dirs, err := parseGateScript(readFile(t, filepath.Join(root, gateScriptPath)))
+	if err != nil {
+		t.Fatalf("cannot read the exclusions from %s: %v", gateScriptPath, err)
+	}
+	return module, dirs
+}
+
+// mustParseCodecovIgnores reads the real Codecov config and fails the test if
+// its ignore list cannot be parsed.
+func mustParseCodecovIgnores(t *testing.T, root string) []string {
+	t.Helper()
+
+	dirs, err := parseCodecovIgnores(readFile(t, filepath.Join(root, codecovConfigPath)))
+	if err != nil {
+		t.Fatalf("cannot read the ignore list from %s: %v", codecovConfigPath, err)
+	}
+	return dirs
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, so the checks work regardless of where the test binary is run from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot determine the working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, goModPath)); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no %s found in any parent of the working directory", goModPath)
+		}
+		dir = parent
+	}
+}
+
+// readFile returns the contents of path, failing the test if it cannot be read.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// diffSets reports the directories present in one list but not the other,
+// returning "" when the two name the same set. Duplicates are collapsed: what
+// matters is which directories are excluded, not how many times each is listed.
+func diffSets(gate, codecov []string) string {
+	inGate := toSet(gate)
+	inCodecov := toSet(codecov)
+
+	missing := difference(inGate, inCodecov)
+	extra := difference(inCodecov, inGate)
+	if len(missing) == 0 && len(extra) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	if len(missing) > 0 {
+		fmt.Fprintf(&b, "  excluded by %s but not by %s: %s\n",
+			gateScriptPath, codecovConfigPath, strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		fmt.Fprintf(&b, "  excluded by %s but not by %s: %s\n",
+			codecovConfigPath, gateScriptPath, strings.Join(extra, ", "))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func toSet(items []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if trimmed := strings.Trim(strings.TrimSpace(item), "/"); trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	return set
+}
+
+func difference(a, b map[string]struct{}) []string {
+	var only []string
+	for item := range a {
+		if _, ok := b[item]; !ok {
+			only = append(only, item)
+		}
+	}
+	sort.Strings(only)
+	return only
+}

--- a/internal/covergate/parsers_test.go
+++ b/internal/covergate/parsers_test.go
@@ -1,0 +1,346 @@
+package covergate
+
+import (
+	"strings"
+	"testing"
+)
+
+// The tests in this file exercise the parsers against inputs the repository
+// does not currently contain. Without them the parsers would only ever see the
+// one shape that exists today, and a regression that made a malformed file
+// parse as "no exclusions" instead of failing would ship undetected — the
+// precise no-op this package exists to prevent.
+
+func TestParseGateScript(t *testing.T) {
+	const valid = `EXCLUDE_RE='^github\.com/go-monolith/mono/(examples|bench|test)/'`
+
+	tests := []struct {
+		name       string
+		content    string
+		wantModule string
+		wantDirs   []string
+		wantErr    string
+	}{
+		{
+			name:       "canonical assignment",
+			content:    "#!/usr/bin/env bash\n" + valid + "\n",
+			wantModule: "github.com/go-monolith/mono",
+			wantDirs:   []string{"examples", "bench", "test"},
+		},
+		{
+			name:       "carriage returns are tolerated",
+			content:    "#!/usr/bin/env bash\r\n" + valid + "\r\n",
+			wantModule: "github.com/go-monolith/mono",
+			wantDirs:   []string{"examples", "bench", "test"},
+		},
+		{
+			name:       "single excluded directory",
+			content:    `EXCLUDE_RE='^example\.com/m/(only)/'`,
+			wantModule: "example.com/m",
+			wantDirs:   []string{"only"},
+		},
+		{
+			name:    "missing assignment",
+			content: "#!/usr/bin/env bash\necho hello\n",
+			wantErr: "no EXCLUDE_RE assignment",
+		},
+		{
+			name:    "renamed variable",
+			content: `EXCLUDED_DIRS='^github\.com/go-monolith/mono/(examples|bench)/'`,
+			wantErr: "no EXCLUDE_RE assignment",
+		},
+		{
+			name:    "double quotes instead of single",
+			content: `EXCLUDE_RE="^github\.com/go-monolith/mono/(examples)/"`,
+			wantErr: "no EXCLUDE_RE assignment",
+		},
+		{
+			name:    "no alternation group",
+			content: `EXCLUDE_RE='^github\.com/go-monolith/mono/examples/'`,
+			wantErr: "no EXCLUDE_RE assignment",
+		},
+		{
+			name:    "duplicate assignments are ambiguous",
+			content: valid + "\n" + `EXCLUDE_RE='^github\.com/go-monolith/mono/(bench)/'` + "\n",
+			wantErr: "found 2 EXCLUDE_RE assignments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module, dirs, err := parseGateScript(tt.content)
+			checkErr(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				return
+			}
+			if module != tt.wantModule {
+				t.Errorf("module = %q, want %q", module, tt.wantModule)
+			}
+			if !equalStrings(dirs, tt.wantDirs) {
+				t.Errorf("dirs = %v, want %v", dirs, tt.wantDirs)
+			}
+		})
+	}
+}
+
+func TestParseCodecovIgnores(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantDirs []string
+		wantErr  string
+	}{
+		{
+			name:     "canonical block",
+			content:  "ignore:\n  - \"examples/**\"\n  - \"bench/**\"\n",
+			wantDirs: []string{"examples", "bench"},
+		},
+		{
+			name:     "comments and blank lines do not end the block",
+			content:  "# leading comment\n\nignore:\n  # why examples are excluded\n  - \"examples/**\"\n\n  - \"bench/**\"\n",
+			wantDirs: []string{"examples", "bench"},
+		},
+		{
+			name:     "carriage returns are tolerated",
+			content:  "ignore:\r\n  - \"examples/**\"\r\n  - \"bench/**\"\r\n",
+			wantDirs: []string{"examples", "bench"},
+		},
+		{
+			name:     "unindented list entries",
+			content:  "ignore:\n- \"examples/**\"\n- \"bench/**\"\n",
+			wantDirs: []string{"examples", "bench"},
+		},
+		{
+			name:     "a later top-level key ends the block",
+			content:  "ignore:\n  - \"examples/**\"\ncomment:\n  require_changes: true\n",
+			wantDirs: []string{"examples"},
+		},
+		{
+			name:     "nested paths are preserved",
+			content:  "ignore:\n  - \"internal/vendor/**\"\n",
+			wantDirs: []string{"internal/vendor"},
+		},
+		{
+			name:    "no ignore key at all",
+			content: "coverage:\n  status:\n    project:\n      default:\n        target: 80%\n",
+			wantErr: "no top-level ignore: key",
+		},
+		{
+			name:    "ignore nested under another key is not top level",
+			content: "coverage:\n  ignore:\n    - \"examples/**\"\n",
+			wantErr: "no top-level ignore: key",
+		},
+		{
+			name:    "duplicate top-level ignore keys are ambiguous",
+			content: "ignore:\n  - \"examples/**\"\ncomment:\n  require_changes: true\nignore:\n  - \"bench/**\"\n",
+			wantErr: "found 2 top-level ignore: keys",
+		},
+		{
+			name:    "flow style is not silently accepted",
+			content: "ignore: [\"examples/**\", \"bench/**\"]\n",
+			wantErr: "no top-level ignore: key",
+		},
+		{
+			name:    "unquoted entry is rejected rather than skipped",
+			content: "ignore:\n  - examples/**\n",
+			wantErr: "unrecognised entry",
+		},
+		{
+			name:    "entry without the glob suffix is rejected",
+			content: "ignore:\n  - \"examples\"\n",
+			wantErr: "unrecognised entry",
+		},
+		{
+			name:    "empty block",
+			content: "ignore:\ncomment:\n  require_changes: true\n",
+			wantErr: "ignore: list is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirs, err := parseCodecovIgnores(tt.content)
+			checkErr(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				return
+			}
+			if !equalStrings(dirs, tt.wantDirs) {
+				t.Errorf("dirs = %v, want %v", dirs, tt.wantDirs)
+			}
+		})
+	}
+}
+
+func TestParseCodecovFixes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "canonical entry",
+			content: "fixes:\n  - \"github.com/go-monolith/mono/::\"\n",
+			want:    "github.com/go-monolith/mono",
+		},
+		{
+			name:    "carriage returns are tolerated",
+			content: "fixes:\r\n  - \"github.com/go-monolith/mono/::\"\r\n",
+			want:    "github.com/go-monolith/mono",
+		},
+		{
+			name:    "missing entry",
+			content: "ignore:\n  - \"examples/**\"\n",
+			wantErr: "no fixes: entry",
+		},
+		{
+			name:    "duplicate entries are ambiguous",
+			content: "fixes:\n  - \"a/b/::\"\n  - \"c/d/::\"\n",
+			wantErr: "found 2 fixes: prefix entries",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCodecovFixes(tt.content)
+			checkErr(t, err, tt.wantErr)
+			if tt.wantErr == "" && got != tt.want {
+				t.Errorf("prefix = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseModulePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "canonical go.mod",
+			content: "module github.com/go-monolith/mono\n\ngo 1.25.0\n",
+			want:    "github.com/go-monolith/mono",
+		},
+		{
+			name:    "carriage returns are tolerated",
+			content: "module github.com/go-monolith/mono\r\n\r\ngo 1.25.0\r\n",
+			want:    "github.com/go-monolith/mono",
+		},
+		{
+			name:    "a require line naming a module is not the directive",
+			content: "go 1.25.0\n\nrequire (\n\tgithub.com/google/uuid v1.6.0\n)\n",
+			wantErr: "no module directive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseModulePath(tt.content)
+			checkErr(t, err, tt.wantErr)
+			if tt.wantErr == "" && got != tt.want {
+				t.Errorf("module = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiffSets(t *testing.T) {
+	tests := []struct {
+		name     string
+		gate     []string
+		codecov  []string
+		wantDiff bool
+		contains string
+	}{
+		{
+			name:    "identical sets agree",
+			gate:    []string{"examples", "bench", "test"},
+			codecov: []string{"examples", "bench", "test"},
+		},
+		{
+			name:    "order does not matter",
+			gate:    []string{"test", "examples", "bench"},
+			codecov: []string{"examples", "bench", "test"},
+		},
+		{
+			name:    "trailing slashes are normalised away",
+			gate:    []string{"examples/", "bench"},
+			codecov: []string{"examples", "bench/"},
+		},
+		{
+			name:     "directory only in the gate script",
+			gate:     []string{"examples", "bench"},
+			codecov:  []string{"examples"},
+			wantDiff: true,
+			contains: "but not by " + codecovConfigPath + ": bench",
+		},
+		{
+			name:     "directory only in codecov.yml",
+			gate:     []string{"examples"},
+			codecov:  []string{"examples", "docs"},
+			wantDiff: true,
+			contains: "but not by " + gateScriptPath + ": docs",
+		},
+		{
+			name:     "disjoint sets report both directions",
+			gate:     []string{"a"},
+			codecov:  []string{"b"},
+			wantDiff: true,
+			contains: "excluded by",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff := diffSets(tt.gate, tt.codecov)
+			if tt.wantDiff && diff == "" {
+				t.Fatal("expected a reported difference, got none")
+			}
+			if !tt.wantDiff && diff != "" {
+				t.Fatalf("expected no difference, got:\n%s", diff)
+			}
+			if tt.contains != "" && !strings.Contains(diff, tt.contains) {
+				t.Errorf("diff %q does not mention %q", diff, tt.contains)
+			}
+		})
+	}
+}
+
+// TestExcludeReUsePatternMatchesRealUsage keeps the "is EXCLUDE_RE actually
+// applied" check honest: the pattern must match the form the script uses and
+// must not match a call that filters on something else.
+func TestExcludeReUsePattern(t *testing.T) {
+	if !excludeReUsePattern.MatchString(`grep -Ev "$EXCLUDE_RE" <(tail -n +2 "$PROFILE")`) {
+		t.Error("pattern does not match the form the gate script uses")
+	}
+	if excludeReUsePattern.MatchString(`grep -Ev "$SOMETHING_ELSE" file`) {
+		t.Error("pattern matches a filter on an unrelated variable")
+	}
+}
+
+func checkErr(t *testing.T, err error, want string) {
+	t.Helper()
+
+	switch {
+	case want == "" && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	case want != "" && err == nil:
+		t.Fatalf("expected an error containing %q, got none", want)
+	case want != "" && !strings.Contains(err.Error(), want):
+		t.Fatalf("error %q does not contain %q", err, want)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/lifecycle/manager_test.go
+++ b/internal/lifecycle/manager_test.go
@@ -4815,7 +4815,6 @@ func TestLifecycleManager_StreamConsumerSetupError(t *testing.T) {
 					},
 					Consumer: types.ConsumerConfig{
 						Name:        "test-consumer",
-						Durable:     "test-consumer",
 						Description: "test consumer",
 					},
 				},

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -33,7 +33,20 @@ EXCLUDE_RE='^github\.com/go-monolith/mono/(examples|bench|test)/'
 # from a single package would be a few hundred and would still yield a
 # plausible-looking percentage, so refuse to measure one at all rather than
 # report a number computed over almost nothing.
-MIN_STATEMENTS="${COVERAGE_MIN_STATEMENTS:-4000}"
+#
+# The primary signal is the number of distinct packages, because that is stable
+# across toolchains in a way the statement count is not: the same tree reports
+# 3807 in-scope statements under Go 1.26 and 5226 under Go 1.27, since the
+# compiler's statement-counting granularity changes between releases. A floor
+# calibrated on one toolchain therefore fails spuriously on another, while the
+# package count stays put. A full run covers roughly 18 in-scope packages; a
+# truncated single-package run covers one.
+MIN_PACKAGES="${COVERAGE_MIN_PACKAGES:-10}"
+
+# Secondary backstop, deliberately far below the smallest figure any supported
+# toolchain reports, so it catches an obviously empty profile without needing
+# recalibration every Go release.
+MIN_STATEMENTS="${COVERAGE_MIN_STATEMENTS:-2000}"
 
 if [ ! -f "$PROFILE" ]; then
 	echo "coverage-gate: no coverage profile at '$PROFILE'" >&2
@@ -50,9 +63,15 @@ fi
 head -n 1 "$PROFILE" >"$FILTERED"
 grep -Ev "$EXCLUDE_RE" <(tail -n +2 "$PROFILE") >>"$FILTERED" || true
 
+# Package of a profile line: everything up to the last "/" of the file path,
+# which is the field before the first ":".
+packages="$(awk 'NR > 1 { sub(/:.*/, "", $1); sub(/\/[^\/]*$/, "", $1); print $1 }' "$FILTERED" | sort -u | wc -l)"
 statements="$(awk 'NR > 1 { total += $2 } END { print total + 0 }' "$FILTERED")"
-if [ "$statements" -lt "$MIN_STATEMENTS" ]; then
-	echo "coverage-gate: only $statements in-scope statements in '$PROFILE' (expected at least $MIN_STATEMENTS)." >&2
+
+if [ "$packages" -lt "$MIN_PACKAGES" ] || [ "$statements" -lt "$MIN_STATEMENTS" ]; then
+	echo "coverage-gate: '$PROFILE' is too small to measure." >&2
+	echo "  in-scope packages: $packages (need at least $MIN_PACKAGES)" >&2
+	echo "  in-scope statements: $statements (need at least $MIN_STATEMENTS)" >&2
 	echo "That profile is truncated or stale — measuring it would report a meaningless percentage." >&2
 	echo "Re-run a full profile with: make test-coverage-ci" >&2
 	exit 1

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# coverage-gate.sh — enforce a minimum statement-coverage floor.
+#
+# Reads a Go coverage profile, strips the packages that are out of scope for
+# the floor, prints the per-package breakdown, and exits non-zero when the
+# remaining figure is below the threshold.
+#
+# Usage:
+#   scripts/coverage-gate.sh [profile] [threshold]
+#   COVERAGE_FILE=coverage.out COVERAGE_THRESHOLD=80 scripts/coverage-gate.sh
+#
+# Normally invoked as `make test-coverage-check`, which produces the profile
+# first.
+
+set -euo pipefail
+
+PROFILE="${1:-${COVERAGE_FILE:-coverage.out}}"
+THRESHOLD="${2:-${COVERAGE_THRESHOLD:-80}}"
+FILTERED="${COVERAGE_FILTERED:-coverage.filtered.out}"
+
+# Packages excluded from the floor. Keep this list in lockstep with the
+# `ignore:` list in codecov.yml — the two drifting apart is how the badge and
+# the gate end up reporting different numbers.
+#
+#   examples/  documentation programs, no tests by design
+#   bench/     benchmarks and the benchmark JSON parser
+#   test/      integration suite, run separately under -tags=integration
+EXCLUDE_RE='^github\.com/go-monolith/mono/(examples|bench|test)/'
+
+# A full unit-test run reports well over 5000 in-scope statements. A profile
+# from a single package would be a few hundred and would still yield a
+# plausible-looking percentage, so refuse to measure one at all rather than
+# report a number computed over almost nothing.
+MIN_STATEMENTS="${COVERAGE_MIN_STATEMENTS:-4000}"
+
+if [ ! -f "$PROFILE" ]; then
+	echo "coverage-gate: no coverage profile at '$PROFILE'" >&2
+	echo "" >&2
+	echo "Produce one with:" >&2
+	echo "  make test-coverage-ci" >&2
+	echo "or:" >&2
+	echo "  go test -race -covermode=atomic -coverprofile=$PROFILE ./..." >&2
+	exit 1
+fi
+
+# The first line of a profile is the `mode:` header; everything after it is one
+# coverage block per line. Keep the header, drop the out-of-scope blocks.
+head -n 1 "$PROFILE" >"$FILTERED"
+grep -Ev "$EXCLUDE_RE" <(tail -n +2 "$PROFILE") >>"$FILTERED" || true
+
+statements="$(awk 'NR > 1 { total += $2 } END { print total + 0 }' "$FILTERED")"
+if [ "$statements" -lt "$MIN_STATEMENTS" ]; then
+	echo "coverage-gate: only $statements in-scope statements in '$PROFILE' (expected at least $MIN_STATEMENTS)." >&2
+	echo "That profile is truncated or stale — measuring it would report a meaningless percentage." >&2
+	echo "Re-run a full profile with: make test-coverage-ci" >&2
+	exit 1
+fi
+
+echo "Coverage by package (excluding examples/, bench/, test/):"
+go tool cover -func="$FILTERED"
+echo ""
+
+total="$(go tool cover -func="$FILTERED" | awk '/^total:/ { gsub(/%/, "", $NF); print $NF }')"
+
+if [ -z "$total" ]; then
+	echo "coverage-gate: could not parse a total from 'go tool cover -func=$FILTERED'" >&2
+	exit 1
+fi
+
+# awk rather than bc: bc is not guaranteed to be present in CI images.
+if awk -v have="$total" -v want="$THRESHOLD" 'BEGIN { exit !(have + 0 < want + 0) }'; then
+	echo "FAIL: coverage ${total}% is below the required ${THRESHOLD}% floor." >&2
+	echo "$statements in-scope statements were measured; see the table above for the least-covered packages." >&2
+	exit 1
+fi
+
+echo "OK: coverage ${total}% meets the ${THRESHOLD}% floor ($statements in-scope statements)."

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -21,7 +21,8 @@ FILTERED="${COVERAGE_FILTERED:-coverage.filtered.out}"
 
 # Packages excluded from the floor. Keep this list in lockstep with the
 # `ignore:` list in codecov.yml — the two drifting apart is how the badge and
-# the gate end up reporting different numbers.
+# the gate end up reporting different numbers. internal/covergate enforces
+# that; it parses this assignment, so changing its shape fails those tests.
 #
 #   examples/  documentation programs, no tests by design
 #   bench/     benchmarks and the benchmark JSON parser


### PR DESCRIPTION
## 📌 Background

The repository had no Codecov integration at all (`grep -rni codecov` returned zero hits). What stood in for it:

- `README.md` — a **hardcoded static** shields.io badge claiming `coverage-90.1%`
- `docs/official/extra/code-coverage.md` — a hand-transcribed per-package table stamped *"Last Updated December 2024"*
- `DEVELOPMENT.md:169` — a stated ">80% code coverage" target with no mechanism behind it
- `make test-coverage` — generated a profile and an HTML report locally, but nothing enforced a floor and nothing uploaded

## 🔧 Reason for Changes

Both the badge number and the ">80%" rule were claims maintained by hand, which means they can drift from reality silently and nothing catches it. This PR makes both real: CI measures coverage on every PR and every push to `main`, uploads it to Codecov for a live badge, and fails the build when the in-scope figure drops below 80%.

## ✅ Changes Implemented

**`scripts/coverage-gate.sh`** (new) — filters the profile to the packages the floor applies to, prints the per-package breakdown, exits non-zero below threshold.

- Uses `go tool cover -func`, verified against a direct sum over the raw profile for this repo (92.48% vs 92.5%), so no custom profile parser is warranted here.
- Includes a tripwire that refuses to measure a profile with implausibly few statements — a truncated or stale run would otherwise report a plausible-looking percentage computed over almost nothing.

**`Makefile`** — two new targets:

- `test-coverage-ci` produces the profile: no `-v` (the verbose log of a `-race` run buries everything else in CI output), no HTML, and the **same 3-attempt retry the existing `test` target uses** — the unit suite is flaky enough under `-race` that a single-shot run would regularly leave the gate with no profile to measure.
- `test-coverage-check` gates on it. `COVERAGE_THRESHOLD` uses `?=` so it can be overridden from the environment or command line without editing the file.
- Neither is wired into `check` or `pre-commit`; a full `-race` coverage run would make the pre-commit hook painfully slow.

**Workflows** — both run **profile → upload → gate as three separate steps** rather than one combined target, so a run that fails the floor still publishes the numbers that explain why.

- `build-test-on-pr-main.yaml`: pinned to a single matrix leg. The figure doesn't meaningfully vary by toolchain version, and running it on all six legs would send Codecov six duplicate uploads of the same commit.
- `release-on-push-main.yaml`: this is what gives Codecov a `main` base report — without it, per-PR coverage deltas have nothing to diff against.
- The upload step is `continue-on-error` because PRs from forks cannot read the repository secret, and `fail_ci_if_error` alone does not cover a failed CLI download.

**`codecov.yml`** (new) — project status mirrors the gate's 80% floor so the Codecov check and CI agree rather than contradict. Patch status is informational (a strict per-diff target turns docs and refactor PRs red for no useful reason). The `fixes:` entry is **required**: Go writes import paths into every profile line while Codecov's ignore globs are root-anchored, so without it the exclusions match nothing.

**`README.md`** — the static badge is **replaced**, not supplemented, so the README can't show two conflicting numbers.

**`docs/official/extra/code-coverage.md`** — rewritten. The stale hardcoded tables are gone; the page now documents the floor, how to run it locally, and why each tree is excluded, and points at the dashboard as the source of truth.

**`internal/covergate/`** (new) — a test-only package that enforces the exclusion lockstep automatically instead of relying on comments.

It parses `scripts/coverage-gate.sh`, `codecov.yml` and `go.mod` with stdlib only (no YAML dependency — the foundation spec caps deps at NATS + stdlib) and fails when they disagree. Beyond simple disagreement it catches two failure modes that a naive comparison misses: `EXCLUDE_RE` being assigned but never applied (the gate would measure every package while the lists still matched), and an exclusion naming a directory that no longer exists (both files agree, both are stale no-ops).

It lives in a Go test rather than a `make check` step because **neither workflow runs `make check`** — a script wired there would never guard a PR. `go list ./...` picks this up, so it runs under `make test`, `make test-short` and both workflows with no new wiring. Being test-only (apart from `doc.go`) it adds no statements and cannot move the floor.

The parsers are pure functions returning errors rather than helpers that abort via `t.Fatalf`, so the guard's own logic is covered by table-driven tests — CRLF input, nested and duplicate `ignore:` keys, flow-style YAML, unquoted entries, duplicate `EXCLUDE_RE` assignments. A drift guard whose parser silently matches nothing is worse than no guard, so every parse failure is loud and says what to do about it.

**`actionlint`** — workflow files are the one part of the repo CI cannot validate by running it: a typo in a matrix reference or an `if:` condition fails open, silently skipping the step it guards while the job still reports success. That is not hypothetical here — the coverage upload is guarded by `if: matrix.go-version == '1.26'`, and a misspelling there would disable coverage entirely without turning anything red.

`lint` now runs `lint-go` + `lint-actions` (separate targets, so either runs alone); `install`/`install-tools` install actionlint pinned via `ACTIONLINT_VERSION`; the lint workflow calls `make install-actionlint` + `make lint-actions` rather than hardcoding the version a second time, since duplicating the pin would recreate the exact two-copy drift `internal/covergate` exists to catch. `lint-actions` errors when actionlint is missing rather than skipping.

This surfaced one real issue, now fixed: **SC2129** in the release workflow's benchmark step, which wrote three consecutive lines to `$GITHUB_OUTPUT` via individual redirects. That code predates this branch, but a lint gate that is red on arrival is worthless, so it had to be green before the check could be wired in.

### Coverage exclusions

`examples/`, `bench/`, `test/` — listed in **both** `codecov.yml` and the gate script, with cross-referencing comments in each, since the two drifting apart is the obvious failure mode. Including them would measure how much example code the repo carries rather than how well the framework is tested: the raw `./...` figure is **61.0%** against **92.3%** in-scope, almost entirely `examples/`.

## 🔍 Testing Results

Measured on this branch: **92.3%** in-scope (5226 statements) — roughly 12 points of headroom over the floor on day one.

- [x] Unit tests passed
- [x] Integration tests passed (unchanged by this PR; coverage profile is unit-only by design)
- [ ] Manually benchmark in local with results attached — N/A, no runtime code changed

Gate behaviour exercised directly:

| Check | Result |
|---|---|
| `make test-coverage-check` (floor 80) | passes at 92.3% |
| `make COVERAGE_THRESHOLD=99 test-coverage-check` | exits 1, names actual vs required |
| Single-package profile (117 statements) | aborts as truncated/stale |
| Missing profile | exits 1 with the command to produce one |
| `COVERAGE_THRESHOLD` via env / CLI / default | all three resolve correctly |
| `codecov.yml` + both workflows | parse as valid YAML |
| `scripts/coverage-gate.sh` | `bash -n` clean, committed mode `100755` |

Drift guard proven to fail rather than merely pass — each input perturbed in turn, then restored:

| Perturbation | Result |
|---|---|
| Extra `docs/**` in `codecov.yml` only | fails, names `docs` and which side has it |
| `test` removed from `EXCLUDE_RE` only | fails, names `test` |
| Module renamed in `go.mod` | fails on both the gate anchor and the `fixes:` prefix |
| `EXCLUDE_RE` renamed (shape change) | fails loudly rather than parsing nothing |
| `fixes:` entry deleted | fails, explains the silent no-op it causes |
| `EXCLUDE_RE` assigned but never applied | fails |
| Duplicate `EXCLUDE_RE` assignment | fails as ambiguous (bash uses the last) |
| Excluded directory renamed on disk | fails, names the stale directory |
| All restored | passes |

10 tests / 34 subtests pass. Coverage figure and statement count unchanged (92.3%, 5226) — the guard adds no statements.

**Workflow semantics validated.** `actionlint` (with `shellcheck` active) now runs clean over all four workflows, and was verified to actually catch errors by misspelling a matrix property. It is wired into `make lint` and into the lint workflow, so this stays checked rather than being a one-off.

## ❗ Breaking Changes / Migration Details

None. No runtime code changed — this is CI, build tooling, and documentation only. Existing `make` targets keep their current behaviour; `test-coverage-ci` and `test-coverage-check` are additive.

### 🔧 Issues found by CI and fixed on this branch

Two failures surfaced that were **not** introduced by the Codecov work, plus one that was:

| Failure | Cause | Fix |
|---|---|---|
| `lint` job panicked | `panic: file requires newer Go version go1.27 (application built with go1.26)`. golangci-lint type-checks the stdlib from source; the workflow pins `go-version: stable`, which became Go 1.27.0, and v2.11.4 was built with go1.26. **Pre-existing** — the first failing run was the commit touching no Go files, and `main`'s last green lint predates Go 1.27, so `main` would fail identically on its next run. | `d7a6882` — bump to v2.13.1 (first release built with go1.27) in both places the pin lives. |
| staticcheck SA1019 | Newer staticcheck flagged a consumer config setting both `Name` and the deprecated `Durable` to the same value. Pre-existing; only use of the field in the repo, and the enclosing test covers a setup-error path, not `Durable` back-compat. | `d7a6882` — dropped the redundant line. |
| `Coverage floor` failed | **Mine.** The truncated-profile tripwire required ≥4000 in-scope statements, a constant calibrated on Go 1.27. The same tree reports **3807** statements under Go 1.26 and **5226** under Go 1.27 — statement-counting granularity changes between releases — and CI runs the coverage leg on 1.26. Coverage itself was never the problem (91.2%). | `7113f73` — the tripwire now keys on distinct in-scope package count (~18 full vs 1 truncated), which a toolchain upgrade does not move, with the statement count kept only as a far-lower backstop. |

Both toolchains verified locally via `GOTOOLCHAIN` (91.2% under 1.26, 92.4% under 1.27), with the tripwire still firing on a single-package profile.

---

### 📝 Additional Notes

**Codecov is already live — no setup needed.** `CODECOV_TOKEN` turned out to be present as an org secret, so the upload works today rather than no-opping as originally assumed. Verified end to end on this PR: the CLI uploaded `coverage.out`, and Codecov's API reports the commit as `state: complete` at **89.94%** over 5488 lines. That figure (rather than the ~61% unfiltered number) confirms the `ignore:` and `fixes:` rules are being applied correctly.

Two observations from the live run:

- The uploader logs a results URL under **`go-monolith/ghtmx`** rather than `go-monolith/mono`. That is cosmetic — it reflects the org token's home project, not where the data went. The `mono` project on Codecov shows `activated: true` and has this commit registered, so attribution is correct.
- Only `codecov/patch` posted a status; `codecov/project` has not appeared yet because `main` has no base report to compare against. The push-to-`main` upload in `release-on-push-main.yaml` is what produces that baseline, so it resolves on merge.
The repo is public, so the README badge needs no `?token=` parameter.

The upload path is proven by this PR's own CI run.

No outstanding follow-ups from this branch beyond the Codecov token setup above.



